### PR TITLE
chore: remove the apache license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 
 [![Pre-Commit](https://github.com/dreadnode/python-template/actions/workflows/pre-commit.yaml/badge.svg)](https://github.com/dreadnode/python-template/actions/workflows/pre-commit.yaml)
 [![Renovate](https://github.com/dreadnode/python-template/actions/workflows/renovate.yaml/badge.svg)](https://github.com/dreadnode/python-template/actions/workflows/renovate.yaml)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 </div>
 <!-- END_AUTO_BADGES -->


### PR DESCRIPTION

---

## Generated Summary:

- Removed the Apache 2.0 license badge from the README.md file.
- This change may impact visibility of the licensing information for users.
- No other modifications made to the README.md.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
