### PR TITLE
chore: version bump to 0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dreadnode"
-version = "0.1.2"
+version = "0.1.3"
 description = "Dreadnode SDK"
 requires-python = ">=3.10,<3.13"
 
@@ -36,7 +36,7 @@ strict = true
 
 [tool.poetry]
 name = "dreadnode"
-version = "0.1.2"
+version = "0.1.3"
 description = "Dreadnode SDK"
 authors = ["Nick Landers <monoxgas@gmail.com>"]
 repository = "https://github.com/dreadnode/sdk"


### PR DESCRIPTION

---

## Generated Summary:

- Bumped project version from 0.1.2 to 0.1.3 in `pyproject.toml`.
- This change ensures compatibility with new features or fixes introduced since the last release.
- Maintains the same Python compatibility restrictions: `>=3.10,<3.13`.
- No changes to the project description or authorship.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
