### PR TITLE
feat(configure): add automatic HTTPS scheme for server URLs without s…

### DIFF
--- a/dreadnode/main.py
+++ b/dreadnode/main.py
@@ -7,7 +7,7 @@ import typing as t
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse, urlunparse
 
 import coolname  # type: ignore [import-untyped]
 import logfire
@@ -204,6 +204,16 @@ class Dreadnode:
                 f"or use environment variables ({ENV_SERVER_URL}, {ENV_API_TOKEN}, {ENV_LOCAL_DIR}).",
                 category=DreadnodeConfigWarning,
             )
+
+        if self.server:
+            parsed_url = urlparse(self.server)
+            if not parsed_url.scheme:
+                netloc = parsed_url.path.split("/")[0]
+                path = "/".join(parsed_url.path.split("/")[1:])
+                parsed_new = parsed_url._replace(
+                    scheme="https", netloc=netloc, path=f"/{path}" if path else ""
+                )
+                self.server = urlunparse(parsed_new)
 
         if self.local_dir is not False:
             config = FileExportConfig(


### PR DESCRIPTION
# Automatic HTTPS Scheme for Server URLs

**Key Changes:**

- [x] Add functionality to automatically prefix server URLs with HTTPS scheme
- [x] Parse URLs without scheme and reconstruct them with HTTPS
- [x] Preserve path components when reconstructing URLs

**Added:**

- [x] URL handling logic that detects missing schemes in server URLs
- [x] Import of additional URL parsing functions (urlparse, urlunparse)

**Changed:**

- [x] Enhanced URL handling in the Dreadnode class
- [x] Import statement expanded to include additional URL parsing utilities

**Removed:**

- [x] N/A


---

## Generated Summary:

- Refactored the server URL handling in the `Dreadnode` class.
- Added a check for the presence of a scheme in the `self.server` URL.
- If the scheme is missing, the code now defaults to `https` and reconstructs the URL.
- This change improves URL handling, ensuring that all URLs processed by the application are valid and secure.
- Potential impact: May prevent connectivity issues if improperly formatted URLs are passed, enhancing reliability.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)


This PR improves user experience by allowing server URLs to be entered without 
explicitly specifying the HTTPS scheme. When a URL is provided without a scheme, 
the system will automatically prepend "https://" to ensure secure connections 
by default.

For example, "example.com/api" will be transformed to "https://example.com/api"
automatically.