### PR TITLE
fix: switched API client routes to full routes

### DIFF
--- a/dreadnode/api/client.py
+++ b/dreadnode/api/client.py
@@ -128,11 +128,11 @@ class ApiClient:
         return Run(**response.json())
 
     def get_run_tasks(self, run: str | ULID) -> list[Task]:
-        response = self.request("GET", f"/strikes/projects/runs/{run!s}/tasks")
+        response = self.request("GET", f"/strikes/projects/runs/{run!s}/tasks/full")
         return [Task(**task) for task in response.json()]
 
     def get_run_trace(self, run: str | ULID) -> list[Task | TraceSpan]:
-        response = self.request("GET", f"/strikes/projects/runs/{run!s}/spans")
+        response = self.request("GET", f"/strikes/projects/runs/{run!s}/spans/full")
         spans: list[Task | TraceSpan] = []
         for item in response.json():
             if "parent_task_span_id" in item:


### PR DESCRIPTION
- summary routes were missing some required attributes
-  routes are intended and include additional details

# Task and Trace Full Response Routes

**Key Changes:**

- [x] API Client now pulls task and track full responses

**Changed:**

- [x] `get_run_tasks` gets from the `/tasks/full` route
- [x] `get_run_trace` gets from the '/spans/full` route

---

## Generated Summary:

- Updated API endpoints in `ApiClient` for fetching run tasks and traces.
- Changed the GET request URL for tasks from `/tasks` to `/tasks/full`, which might return more detailed task information.
- Changed the GET request URL for spans from `/spans` to `/spans/full`, likely providing additional context for trace spans.
- These modifications should improve the detail and usability of the data returned by the API related to run tasks and spans.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
