### PR TITLE
improve: Span Adjustments 

### DIFF
--- a/dreadnode/main.py
+++ b/dreadnode/main.py
@@ -47,7 +47,9 @@ from dreadnode.tracing.span import (
     current_task_span,
 )
 from dreadnode.types import (
+    INHERITED,
     AnyDict,
+    Inherited,
     JsonDict,
     JsonValue,
 )
@@ -412,8 +414,8 @@ class Dreadnode:
         name: str | None = None,
         label: str | None = None,
         log_params: t.Sequence[str] | bool = False,
-        log_inputs: t.Sequence[str] | bool = True,
-        log_output: bool = True,
+        log_inputs: t.Sequence[str] | bool | Inherited = INHERITED,
+        log_output: bool | Inherited = INHERITED,
         tags: t.Sequence[str] | None = None,
         **attributes: t.Any,
     ) -> TaskDecorator: ...
@@ -426,8 +428,8 @@ class Dreadnode:
         name: str | None = None,
         label: str | None = None,
         log_params: t.Sequence[str] | bool = False,
-        log_inputs: t.Sequence[str] | bool = True,
-        log_output: bool = True,
+        log_inputs: t.Sequence[str] | bool | Inherited = INHERITED,
+        log_output: bool | Inherited = INHERITED,
         tags: t.Sequence[str] | None = None,
         **attributes: t.Any,
     ) -> ScoredTaskDecorator[R]: ...
@@ -439,8 +441,8 @@ class Dreadnode:
         name: str | None = None,
         label: str | None = None,
         log_params: t.Sequence[str] | bool = False,
-        log_inputs: t.Sequence[str] | bool = True,
-        log_output: bool = True,
+        log_inputs: t.Sequence[str] | bool | Inherited = INHERITED,
+        log_output: bool | Inherited = INHERITED,
         tags: t.Sequence[str] | None = None,
         **attributes: t.Any,
     ) -> TaskDecorator:
@@ -622,6 +624,7 @@ class Dreadnode:
         tags: t.Sequence[str] | None = None,
         params: AnyDict | None = None,
         project: str | None = None,
+        autolog: bool = True,
         **attributes: t.Any,
     ) -> RunSpan:
         """
@@ -647,6 +650,7 @@ class Dreadnode:
             project: The project name to associate the run with. If not provided,
                 the project passed to `configure()` will be used, or the
                 run will be associated with a default project.
+            autolog: Whether to automatically log task inputs, outputs, and execution metrics if unspecified.
             **attributes: Additional attributes to attach to the run span.
         """
         if not self._initialized:
@@ -664,6 +668,7 @@ class Dreadnode:
             tags=tags,
             file_system=self._fs,
             prefix_path=self._fs_prefix,
+            autolog=autolog,
         )
 
     @handle_internal_errors()

--- a/dreadnode/object.py
+++ b/dreadnode/object.py
@@ -1,12 +1,15 @@
 import typing as t
 from dataclasses import dataclass
 
+from dreadnode.types import JsonDict
+
 
 @dataclass
 class ObjectRef:
     name: str
     label: str
     hash: str
+    attributes: JsonDict
 
 
 @dataclass

--- a/dreadnode/types.py
+++ b/dreadnode/types.py
@@ -23,3 +23,11 @@ class Unset:
 
 
 UNSET: Unset = Unset()
+
+
+class Inherited:
+    def __repr__(self) -> str:
+        return "Inherited"
+
+
+INHERITED: Inherited = Inherited()


### PR DESCRIPTION
- Make some metric key handling stricter.
- Move attributes for objects to refs instead of events.
- Add run-level autolog specs and inheritence. Better  handling for metric names.

---

*Autogenerated:*

- Refactored logging behavior in `Dreadnode` to allow for inherited logging configurations.
- Updated `log_inputs` and `log_output` parameters to support `Inherited` type, defaulting to `INHERITED`.
- Introduced `autolog` functionality to `RunSpan`, enabling automatic logging of task inputs/outputs when unspecified.
- Removed default boolean values for `log_inputs` and `log_output` across several functions, enhancing flexibility.
- Adjusted logging methods in the `Task` class to respect the new configuration and to pay attention to the `autolog` parameter.
- Modified `log_metric` and `log_input` methods in `RunSpan` and `TaskSpan` to support prefixed metric logging, adding contextual clarity.
- Added an `attributes` field to the `ObjectRef` dataclass for better attribute management on logged objects.
- Overall, these changes aim to enhance the logging capabilities, enabling more dynamic and context-driven logging behavior in the Dreadnode framework.