### PR TITLE
fix issue with empty prior_values list

### DIFF
--- a/dreadnode/metric.py
+++ b/dreadnode/metric.py
@@ -87,7 +87,7 @@ class Metric:
         prior_values = [m.value for m in sorted(others, key=lambda m: m.timestamp)]
 
         if mode == "sum":
-            self.value += max(prior_values)
+            self.value = sum([self.value, *prior_values])
         elif mode == "min":
             self.value = min([self.value, *prior_values])
         elif mode == "max":


### PR DESCRIPTION
# Fixes ValueError when passing mode=sum to log_metric

## Observed Behavior:

When you `log_metric("some_metric", some_number, mode="sum")`, the SDK raises the following error. This does not occur for any other aggregation modes.

```
Caught an error in Dreadnode. This will not prevent code from running, but you may lose data.
Traceback (most recent call last):
  File "sdk/dreadnode/task.py", line 326, in __call__
    span = await self.run(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

 [...stack trace...]
 
  File "sdk/dreadnode/metric.py", line 91, in apply_mode
    self.value += max(prior_values)
                  ^^^^^^^^^^^^^^^^^
ValueError: max() arg is an empty sequence
```

## Resolution:

I swapped the summation method for an approach that can handle an empty list.

