### PR TITLE
fix: changed run id type to ULID | str to accomodate old data types

### DIFF
--- a/dreadnode/api/models.py
+++ b/dreadnode/api/models.py
@@ -268,7 +268,7 @@ class ArtifactDir(BaseModel):
 class RunSummary(BaseModel):
     """Summary of a run, containing metadata and basic information."""
 
-    id: ULID
+    id: ULID | str
     """Unique identifier for the run."""
     name: str
     """Name of the run."""


### PR DESCRIPTION
# Allow string type for RunSummary.id field

## Summary
Updates the `RunSummary.id` field type annotation to accept both `ULID` and `str` types.

## Changes
- Modified `RunSummary.id` type from `ULID` to `ULID | str` in the RunSummary model

## Rationale
This change provides more flexibility for the `id` field, allowing it to accept string representations in addition to proper ULID objects. This is useful for scenarios where:
- IDs are received as strings from external APIs or serialized data
- Backward compatibility is needed with existing string-based ID implementations

---

## Generated Summary:

- Updated the `id` field in the `RunSummary` model to support both `ULID` and `str` types.
- This change enhances flexibility in handling different identifier formats for runs.
- The data model now allows for backward compatibility and potential integration with other services that may use string identifiers.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
