### PR TITLE
fix: handle null metric values from platform API changes

### DIFF
--- a/dreadnode/api/models.py
+++ b/dreadnode/api/models.py
@@ -122,7 +122,7 @@ class TraceSpan(BaseModel):
 class Metric(BaseModel):
     """Metric data for a span in a trace."""
 
-    value: float
+    value: float | None
     """Value of the metric."""
     step: int
     """Step or iteration number for the metric."""


### PR DESCRIPTION
**Issue:** SDK failing with Pydantic validation errors after platform API hotfix for NaN handling in metrics.

**Root Cause:** 
- Platform API now converts NaN → null in JSON responses (hotfix #1920)
- SDK Metric model expects `float` but receives `None` for undefined metrics
- Pydantic validation fails: "Input should be a valid number [type=float_type, input_value=None]"

**Solution:** 
- Updated `Metric.value` type from `float` to `float | None`
- Maintains backward compatibility while supporting new API behavior

**Testing:**
✅ Verified SDK can parse responses with null metric values
✅ Existing functionality preserved for valid float values
✅ Authentication and project listing work correctly

**Related:** Platform API hotfix #1920 - NaN JSON serialization fix

Compatible with platform API changes that convert NaN evaluation metrics to null.