### PR TITLE
chore: Bump Version to V1.0.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dreadnode"
-version = "1.0.7"
+version = "1.0.8"
 description = "Dreadnode SDK"
 requires-python = ">=3.10,<3.14"
 


### PR DESCRIPTION
- Bump Version to V1.0.8
---

## Generated Summary:

- Updated version from `1.0.7` to `1.0.8` in `pyproject.toml`.
- This change reflects a new release of the Dreadnode SDK.
- No functional changes to the codebase; changes are versioning only.
- Ensures compatibility with Python versions `>=3.10,<3.14`.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
