### PR TITLE
fix: remove duration parameter from user data credentials API

### DIFF
--- a/docs/sdk/api.mdx
+++ b/docs/sdk/api.mdx
@@ -728,20 +728,10 @@ def get_user(self) -> UserResponse:
 ### get\_user\_data\_credentials
 
 ```python
-get_user_data_credentials(
-    duration: int = DEFAULT_FS_CREDENTIAL_DURATION,
-) -> UserDataCredentials
+get_user_data_credentials() -> UserDataCredentials
 ```
 
 Retrieves user data credentials for secondary storage access.
-
-**Parameters:**
-
-* **`duration`**
-  (`int`, default:
-  `DEFAULT_FS_CREDENTIAL_DURATION`
-  )
-  –Credential lifetime in seconds (default: 4 hours)
 
 **Returns:**
 
@@ -750,19 +740,14 @@ Retrieves user data credentials for secondary storage access.
 
 <Accordion title="Source code in dreadnode/api/client.py" icon="code">
 ```python
-def get_user_data_credentials(
-    self, duration: int = DEFAULT_FS_CREDENTIAL_DURATION
-) -> UserDataCredentials:
+def get_user_data_credentials(self) -> UserDataCredentials:
     """
     Retrieves user data credentials for secondary storage access.
-
-    Args:
-        duration: Credential lifetime in seconds (default: 4 hours)
 
     Returns:
         The user data credentials object.
     """
-    response = self._request("GET", "/user-data/credentials", params={"duration": duration})
+    response = self._request("GET", "/user-data/credentials")
     return UserDataCredentials(**response.json())
 ```
 

--- a/docs/sdk/main.mdx
+++ b/docs/sdk/main.mdx
@@ -526,9 +526,7 @@ def initialize(self) -> None:
         #         )
         #     )
         # )
-        self._credentials = self._api.get_user_data_credentials(
-            duration=DEFAULT_FS_CREDENTIAL_DURATION
-        )
+        self._credentials = self._api.get_user_data_credentials()
         self._credentials_expiry = self._credentials.expiration
         resolved_endpoint = resolve_endpoint(self._credentials.endpoint)
         self._fs = S3FileSystem(

--- a/dreadnode/api/client.py
+++ b/dreadnode/api/client.py
@@ -37,7 +37,6 @@ from dreadnode.api.util import (
     process_task,
 )
 from dreadnode.constants import (
-    DEFAULT_FS_CREDENTIAL_DURATION,
     DEFAULT_MAX_POLL_TIME,
     DEFAULT_POLL_INTERVAL,
 )
@@ -521,17 +520,12 @@ class ApiClient:
 
     # User data access
 
-    def get_user_data_credentials(
-        self, duration: int = DEFAULT_FS_CREDENTIAL_DURATION
-    ) -> UserDataCredentials:
+    def get_user_data_credentials(self) -> UserDataCredentials:
         """
         Retrieves user data credentials for secondary storage access.
-
-        Args:
-            duration: Credential lifetime in seconds (default: 4 hours)
 
         Returns:
             The user data credentials object.
         """
-        response = self._request("GET", "/user-data/credentials", params={"duration": duration})
+        response = self._request("GET", "/user-data/credentials")
         return UserDataCredentials(**response.json())

--- a/dreadnode/constants.py
+++ b/dreadnode/constants.py
@@ -58,5 +58,4 @@ USER_CONFIG_PATH = pathlib.Path(
 )
 
 # Default values for the file system credential management
-DEFAULT_FS_CREDENTIAL_DURATION = 14400  # 4 hours in seconds
 FS_CREDENTIAL_REFRESH_BUFFER = 300  # 5 minutes in seconds

--- a/dreadnode/main.py
+++ b/dreadnode/main.py
@@ -26,7 +26,6 @@ from s3fs import S3FileSystem  # type: ignore [import-untyped]
 from dreadnode.api.client import ApiClient
 from dreadnode.config import UserConfig
 from dreadnode.constants import (
-    DEFAULT_FS_CREDENTIAL_DURATION,
     DEFAULT_SERVER_URL,
     ENV_API_KEY,
     ENV_API_TOKEN,
@@ -353,9 +352,7 @@ class Dreadnode:
             #         )
             #     )
             # )
-            self._credentials = self._api.get_user_data_credentials(
-                duration=DEFAULT_FS_CREDENTIAL_DURATION
-            )
+            self._credentials = self._api.get_user_data_credentials()
             self._credentials_expiry = self._credentials.expiration
             resolved_endpoint = resolve_endpoint(self._credentials.endpoint)
             self._fs = S3FileSystem(
@@ -427,9 +424,7 @@ class Dreadnode:
         ):
             try:
                 logger.info("Refreshing storage credentials")
-                self._credentials = self._api.get_user_data_credentials(
-                    duration=DEFAULT_FS_CREDENTIAL_DURATION
-                )
+                self._credentials = self._api.get_user_data_credentials()
                 self._credentials_expiry = self._credentials.expiration
 
                 resolved_endpoint = resolve_endpoint(self._credentials.endpoint)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dreadnode"
-version = "1.13.1"
+version = "1.13.2"
 description = "Dreadnode SDK"
 requires-python = ">=3.10,<3.14"
 


### PR DESCRIPTION
fix(main): update credential refresh logic for fixed duration

Update credential management to work with server-enforced 1-hour duration:

- Remove DEFAULT_FS_CREDENTIAL_DURATION constant (no longer needed)
- Update _refresh_storage_credentials to not pass duration parameter
- Update initialize() method to use new API signature
- Improve logging in credential refresh method

Resolves AWS role chaining ValidationError for duration > 1 hour
