### PR TITLE
fix: remove caching from CI test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,14 +39,6 @@ jobs:
         poetry config virtualenvs.create true --local
         poetry config virtualenvs.in-project true --local
 
-    - name: Cache dependencies
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-      with:
-        path: ./.venv
-        key: venv-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
-        restore-keys: |
-          venv-${{ runner.os }}-py${{ matrix.python-version }}-
-
     - name: Install package
       run: poetry install --all-extras
 


### PR DESCRIPTION
# Remove caching from CI test workflow

Caching was causing non-deterministic typing errors between the different versions of Python

**Key Changes:**

- [x] removed virtual env caching in the `test` workflow


**Removed:**

- [x] Removed the caching of virtual env

---

## Generated Summary:

- Removed caching of dependencies in GitHub Actions workflow.
- Caching previously utilized `.venv` directory to improve package install speed.
- Potential impact: Slight increase in install time for dependencies, as caching will no longer be used.
- Adjusts workflow to focus solely on the installation step with Poetry.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
