### PR TITLE
fix: added cookies to client request

### DIFF
--- a/dreadnode/api/client.py
+++ b/dreadnode/api/client.py
@@ -99,6 +99,7 @@ class ApiClient:
             headers=headers,
             base_url=self._base_url,
             timeout=30,
+            cookies=_cookies,
         )
 
         if debug:


### PR DESCRIPTION
# Bugfix: dreadnode login

When running the `dreadnode login` command, the device code flow runs properly but the final request with the client othe `/user` endpoint does not included the assembled cookies. 

**Key Changes:**

- [x] fixed `dreadnode login` 401 error

**Changed:**

- [x] added cookies to the httx request

**User Impact**
- resolve `dreadnode login` bug

---

## Generated Summary:

- Added support for passing cookies to the API client.
- Enhanced the flexibility of the `ApiClient` by allowing for session management through cookies.
- Ensures better state management in API requests that require cookies for authentication or tracking.
- No breaking changes introduced; existing functionality remains intact.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
