### PR TITLE
feat: testing centralized lazy imports

### DIFF
--- a/dreadnode/lazy/core.py
+++ b/dreadnode/lazy/core.py
@@ -1,0 +1,81 @@
+import importlib
+import typing as t
+
+if t.TYPE_CHECKING:
+    from types import ModuleType
+
+
+class LazyImportError(ImportError):
+    def __init__(self, module_name: str, extras: str, package_name: str | None = None) -> None:
+        super().__init__(
+            f"Module '{module_name}' is not installed. Please install it with `pip install {package_name or module_name}` or `dreadnode[{extras}]` extras."
+        )
+
+
+class LazyImport:
+    def __init__(self, module_name: str, extras: str, package_name: str | None = None) -> None:
+        self._name = module_name
+        self._extras = extras
+        self._mod: ModuleType | None = None
+        self.package_name = package_name
+
+    def _load(self) -> t.Any:
+        if self._mod is None:
+            try:
+                self._mod = importlib.import_module(self._name)
+            except ModuleNotFoundError as e:
+                if e.name == self._name:
+                    raise LazyImportError(
+                        self._name, self._extras, package_name=self.package_name
+                    ) from None
+                raise
+        return self._mod
+
+    def __getattr__(self, item: str) -> t.Any:
+        return getattr(self._load(), item)
+
+
+class LazyAttr:
+    def __init__(
+        self, module_name: str, attr: str, extras: str, package_name: str | None = None
+    ) -> None:
+        self._module_name = module_name
+        self._attr = attr
+        self._extras = extras
+        self._value = None
+        self.package_name = package_name
+
+    def _load(self) -> t.Any:
+        if self._value is None:
+            try:
+                mod = importlib.import_module(self._module_name)
+                self._value = getattr(mod, self._attr)
+            except ModuleNotFoundError:
+                raise LazyImportError(
+                    self._module_name, self._extras, package_name=self.package_name
+                ) from None
+        return self._value
+
+    def __getattr__(self, item: str) -> t.Any:
+        return getattr(self._load(), item)
+
+    def __call__(self, *args: t.Any, **kwargs: t.Any) -> t.Any:
+        return self._load()(*args, **kwargs)
+
+    def __repr__(self) -> str:
+        status = "loaded" if self._value is not None else "unloaded"
+        return f"<LazyAttr {self._module_name}.{self._attr} ({status})>"
+
+    def __dir__(self) -> list[str]:
+        try:
+            return sorted(set(dir(self._load())))
+        except LazyImportError:
+            return [
+                "__call__",
+                "__getattr__",
+                "_load",
+                "_module_name",
+                "_attr",
+                "_extras",
+                "_value",
+            ]

--- a/dreadnode/lazy/scorers.py
+++ b/dreadnode/lazy/scorers.py
@@ -1,0 +1,48 @@
+import typing as t
+
+from dreadnode.lazy.core import LazyAttr, LazyImport
+
+if t.TYPE_CHECKING:
+    import litellm as litellm  # type: ignore[import-not-found]
+    import nltk as nltk  # type: ignore[import-not-found]
+    from nltk.tokenize import (  # type: ignore[import-not-found]
+        word_tokenize as word_tokenize,
+    )
+    from nltk.translate.bleu_score import (  # type: ignore[import-not-found]
+        sentence_bleu as sentence_bleu,
+    )
+    from rapidfuzz import distance as distance  # type: ignore[import-not-found]
+    from rapidfuzz import fuzz as fuzz  # type: ignore[import-not-found]
+    from rapidfuzz import utils as utils  # type: ignore[import-not-found]
+    from sentence_transformers import (  # type: ignore[import-not-found]
+        SentenceTransformer as SentenceTransformer,
+    )
+    from sentence_transformers import (  # type: ignore[import-not-found]
+        util as util,
+    )
+    from sklearn.feature_extraction.text import (  # type: ignore[import-not-found]
+        TfidfVectorizer as TfidfVectorizer,
+    )
+    from sklearn.metrics.pairwise import (  # type: ignore[import-not-found]
+        cosine_similarity as cosine_similarity,
+    )
+else:
+    fuzz = LazyAttr("rapidfuzz", "fuzz", "text")
+    utils = LazyAttr("rapidfuzz", "utils", "text")
+    distance = LazyAttr("rapidfuzz", "distance", "text")
+    litellm = LazyImport("litellm", "llm")
+    util = LazyAttr("sentence_transformers", "util", "text", package_name="sentence-transformers")
+    TfidfVectorizer = LazyAttr(
+        "sklearn.feature_extraction.text", "TfidfVectorizer", "text", package_name="scikit-learn"
+    )
+    SentenceTransformer = LazyAttr(
+        "sentence_transformers", "SentenceTransformer", "text", package_name="sentence-transformers"
+    )
+    cosine_similarity = LazyAttr(
+        "sklearn.metrics.pairwise", "cosine_similarity", "text", package_name="scikit-learn"
+    )
+    nltk = LazyImport("nltk", "text")
+    word_tokenize = LazyAttr("nltk.tokenize", "word_tokenize", "text", package_name="nltk")
+    sentence_bleu = LazyAttr(
+        "nltk.translate.bleu_score", "sentence_bleu", "text", package_name="nltk"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,9 +112,10 @@ exclude = "tests"
 module = [
     "dreadnode.data_types.*",
     "dreadnode.scorers.*",
+    "dreadnode.lazy.*",
     "dreadnode.transforms.*",
 ]
-disable_error_code = ["unused-ignore", "import-untyped"]
+disable_error_code = ["unused-ignore", "import-untyped", "import-not-found"]
 
 [tool.ty.environment]
 python-version = "3.10"
@@ -179,4 +180,7 @@ skip-magic-trailing-comma = false
     "INP001", # namespace not required for pytest
     "S101",   # asserts allowed in tests...
     "SLF001", # allow access to private members
+]
+"dreadnode/lazy/*.py" = [
+    "PLC0414", # keep naming the same as the real package
 ]


### PR DESCRIPTION
# Central Lazy Loading System

In order to make the lazy loading process more DRY, I've attempted to centralize the lazy imports for scorers.


**Key Changes:**

- [x] Created a central lazy loading system for modules and attrs
- [x] Created a centralized "scorer" lazy loading system and dependencies
- [x] Updated the `similarity` scorers as PoCs

**Notes**
- Missing imports are handled nicely in the scores (and optionally) via the `catch` kwarg in the `Scorer`
