### PR TITLE
chore: add examples folder to pypi distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ build-backend = "hatchling.build"
 packages = ["dreadnode"]
 
 [tool.hatch.build.targets.sdist]
-include = ["/dreadnode", "/tests", "/README.md", "/LICENSE"]
+include = ["/dreadnode", "/tests", "/examples", "/README.md", "/LICENSE"]
 
 # Dev
 


### PR DESCRIPTION
**Key Changes:**
- Include examples folder in PyPI package

Customer note: Example scripts are now bundled in the package to help get started quickly.
---

## Generated Summary:

- Updated the `pyproject.toml` file to include the `/examples` directory in the source distribution (sdist) build.
- This change allows users to access example code when installing the package from the source distribution.
- No changes were made to package dependencies or functionality.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
