### PR TITLE
add IA structure to SDK repo

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -93,19 +93,34 @@
       {
         "group": "SDK",
         "pages": [
-          "sdk/airt",
-          "sdk/api",
-          "sdk/artifact",
-          "sdk/data_types",
-          "sdk/eval",
-          "sdk/integrations",
-          "sdk/main",
-          "sdk/metric",
-          "sdk/optimization",
-          "sdk/scorers",
-          "sdk/serialization",
-          "sdk/task",
-          "sdk/transforms"
+          {
+            "group": "Core",
+            "pages": [
+              "strikes/sdk/main",
+              "strikes/sdk/task",
+              "strikes/sdk/api"
+            ]
+          },
+          {
+            "group": "Data and Processing",
+            "pages": [
+              "strikes/sdk/data_types",
+              "strikes/sdk/serialization",
+              "strikes/sdk/artifact",
+              "strikes/sdk/transforms",
+              "strikes/sdk/optimization"
+            ]
+          },
+          {
+            "group": "Evaluation and Integrations",
+            "pages": [
+              "strikes/sdk/eval",
+              "strikes/sdk/metrics",
+              "strikes/sdk/scorers",
+              "strikes/sdk/integrations",
+              "strikes/sdk/airt"
+            ]
+          }
         ]
       }
     ]


### PR DESCRIPTION
# Adding more IA structure to SDK docs

**Key Changes:**
- adding sections to the SDK docs for easier finding

**Changed:**
- Updated SDK docs to now have three new subsections
---

## Generated Summary:

- Updated the documentation structure for the SDK in `docs/docs.json`.
- Introduced three new groups: 
  - Core
  - Data and Processing
  - Evaluation and Integrations
- Each group contains relevant pages that were previously listed individually.
- Enhances organization and accessibility of SDK documentation.
- Potentially improves onboarding and navigation for developers using the SDK.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
