### PR TITLE
fix: Agent tool generics

### DIFF
--- a/dreadnode/__init__.py
+++ b/dreadnode/__init__.py
@@ -37,6 +37,7 @@ from dreadnode.version import VERSION
 
 if t.TYPE_CHECKING:
     from dreadnode import agent, airt, eval, optimization, scorers, transforms  # noqa: A004
+    from dreadnode.agent import Agent, tool, tool_method
     from dreadnode.data_types import Audio, Image, Table, Video
 
 logger.disable("dreadnode")
@@ -75,6 +76,7 @@ __version__ = VERSION
 
 __all__ = [
     "DEFAULT_INSTANCE",
+    "Agent",
     "Audio",
     "Code",
     "Config",
@@ -138,6 +140,8 @@ __all__ = [
     "task",
     "task_and_run",
     "task_span",
+    "tool",
+    "tool_method",
     "transforms",
 ]
 
@@ -147,6 +151,9 @@ __lazy_components__: dict[str, str] = {
     "Image": "dreadnode.data_types",
     "Table": "dreadnode.data_types",
     "Video": "dreadnode.data_types",
+    "Agent": "dreadnode.agent",
+    "tool": "dreadnode.agent",
+    "tool_method": "dreadnode.agent",
 }
 
 

--- a/dreadnode/agent/__init__.py
+++ b/dreadnode/agent/__init__.py
@@ -4,6 +4,7 @@ from dreadnode.agent import error, events, hooks, reactions, result, stop, tools
 from dreadnode.agent.agent import Agent
 from dreadnode.agent.result import AgentResult
 from dreadnode.agent.thread import Thread
+from dreadnode.agent.tools import tool, tool_method
 
 Agent.model_rebuild()
 Thread.model_rebuild()
@@ -20,5 +21,7 @@ __all__ = [
     "reactions",
     "result",
     "stop",
+    "tool",
+    "tool_method",
     "tools",
 ]

--- a/dreadnode/agent/agent.py
+++ b/dreadnode/agent/agent.py
@@ -4,7 +4,7 @@ from contextlib import aclosing, asynccontextmanager
 from copy import deepcopy
 
 import rigging as rg
-from pydantic import ConfigDict, Field, PrivateAttr, field_validator
+from pydantic import ConfigDict, Field, PrivateAttr, SkipValidation, field_validator
 from rigging.message import inject_system_content  # can't access via rg
 
 from dreadnode.agent.error import MaxStepsError
@@ -83,7 +83,7 @@ class Agent(Model):
     caching: rg.caching.CacheMode | None = Config(default=None, repr=False)
     """How to handle cache_control entries on inference messages."""
 
-    tools: list[AnyTool | Toolset] = Config(default_factory=list)
+    tools: t.Annotated[list[AnyTool | Toolset], SkipValidation] = Config(default_factory=list)
     """Tools the agent can use."""
     tool_mode: ToolMode = Config(default="auto", repr=False)
     """The tool calling mode to use."""

--- a/dreadnode/agent/tools/__init__.py
+++ b/dreadnode/agent/tools/__init__.py
@@ -3,7 +3,12 @@ import typing as t
 
 from dreadnode.agent.tools.base import (
     AnyTool,
+    FunctionCall,
+    FunctionDefinition,
     Tool,
+    ToolCall,
+    ToolDefinition,
+    ToolMode,
     Toolset,
     discover_tools_on_obj,
     tool,
@@ -15,7 +20,12 @@ if t.TYPE_CHECKING:
 
 __all__ = [
     "AnyTool",
+    "FunctionCall",
+    "FunctionDefinition",
     "Tool",
+    "ToolCall",
+    "ToolDefinition",
+    "ToolMode",
     "Toolset",
     "discover_tools_on_obj",
     "fs",

--- a/dreadnode/agent/tools/base.py
+++ b/dreadnode/agent/tools/base.py
@@ -8,6 +8,10 @@ from dreadnode.meta import Component, Config, Model
 
 Tool = tools.Tool
 ToolMode = tools.ToolMode
+ToolCall = tools.ToolCall
+FunctionCall = tools.FunctionCall
+ToolDefinition = tools.ToolDefinition
+FunctionDefinition = tools.FunctionDefinition
 
 AnyTool = Tool[t.Any, t.Any]
 

--- a/uv.lock
+++ b/uv.lock
@@ -681,7 +681,7 @@ wheels = [
 
 [[package]]
 name = "dreadnode"
-version = "1.14.0"
+version = "1.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "coolname" },


### PR DESCRIPTION
- Fixed a bug where `PrivateAttr` fields on tools would get wiped due to round trip model construction caused by generics on the Agent `.tools` field.
- Adjusted some imports to make it easier to access `Agent`, `@tool`, and `@tool_method`.

---

## Generated Summary:

- Added imports for `Agent`, `tool`, and `tool_method` in `dreadnode/__init__.py`.
- Updated the `__all__` exports to include `Agent`, `tool`, and `tool_method`, ensuring they are accessible at the package level.
- Enhanced lazy component registrations to include `Agent`, `tool`, and `tool_method` in `__lazy_components__`.
- Imported `tool` and `tool_method` in `dreadnode.agent` to ensure their availability across agent modules.
- Refined the type annotations of `tools` in the `Agent` class to use `t.Annotated` with `SkipValidation`, which improves validation handling.
- Extended the `__all__` export list in `dreadnode.agent.tools` to expose `FunctionCall`, `FunctionDefinition`, `ToolCall`, and `ToolDefinition`, expanding the toolkit's usability.
- Introduced new type definitions in `dreadnode.agent.tools.base`, establishing a clearer API for tool-related functionality.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
