### PR TITLE
feat: Multi user context

### DIFF
--- a/docs/sdk/main.mdx
+++ b/docs/sdk/main.mdx
@@ -423,17 +423,7 @@ def get_run_context(self) -> RunContext:
     """
     if (run := current_run_span.get()) is None:
         raise RuntimeError("get_run_context() must be called within a run")
-
-    # Capture OpenTelemetry trace context
-    trace_context: dict[str, str] = {}
-    propagate.inject(trace_context)
-
-    return {
-        "run_id": run.run_id,
-        "run_name": run.name,
-        "project": run.project,
-        "trace_context": trace_context,
-    }
+    return run.get_context()
 ```
 
 
@@ -501,30 +491,8 @@ def initialize(self) -> None:
                 f"Failed to connect to the Dreadnode server: {e}",
             ) from e
 
-        headers = {"User-Agent": f"dreadnode/{VERSION}", "X-Api-Key": self.token}
-        span_processors.append(
-            BatchSpanProcessor(
-                RemovePendingSpansExporter(  # This will tell Logfire to emit pending spans to us as well
-                    OTLPSpanExporter(
-                        endpoint=urljoin(self.server, "/api/otel/traces"),
-                        headers=headers,
-                        compression=Compression.Gzip,
-                    ),
-                ),
-            ),
-        )
-        # TODO(nick): Metrics
-        # https://linear.app/dreadnode/issue/ENG-1310/sdk-add-metrics-exports
-        # metric_readers.append(
-        #     PeriodicExportingMetricReader(
-        #         OTLPMetricExporter(
-        #             endpoint=urljoin(self.server, "/v1/metrics"),
-        #             headers=headers,
-        #             compression=Compression.Gzip,
-        #             # preferred_temporality
-        #         )
-        #     )
-        # )
+        span_processors.append(RoutingSpanProcessor(self.server, self.token))
+
         if self._api is not None:
             api = self._api
             self._credential_manager = CredentialManager(
@@ -1750,6 +1718,7 @@ run(
     project: str | None = None,
     autolog: bool = True,
     name_prefix: str | None = None,
+    api_key: str | None = None,
     attributes: AnyDict | None = None,
 ) -> RunSpan
 ```
@@ -1799,6 +1768,16 @@ with dreadnode.run("my_run"):
   `True`
   )
   –Automatically log task inputs, outputs, and execution metrics if otherwise unspecified.
+* **`name_prefix`**
+  (`str | None`, default:
+  `None`
+  )
+  –A prefix to use when generating a random name for the run.
+* **`api_key`**
+  (`str | None`, default:
+  `None`
+  )
+  –An optional API key to use for tracing this run instead of the configured one.
 * **`attributes`**
   (`AnyDict | None`, default:
   `None`
@@ -1823,6 +1802,7 @@ def run(
     project: str | None = None,
     autolog: bool = True,
     name_prefix: str | None = None,
+    api_key: str | None = None,
     attributes: AnyDict | None = None,
 ) -> RunSpan:
     """
@@ -1849,6 +1829,8 @@ def run(
             the project passed to `configure()` will be used, or the
             run will be associated with a default project.
         autolog: Automatically log task inputs, outputs, and execution metrics if otherwise unspecified.
+        name_prefix: A prefix to use when generating a random name for the run.
+        api_key: An optional API key to use for tracing this run instead of the configured one.
         attributes: Additional attributes to attach to the run span.
 
     Returns:
@@ -1870,6 +1852,7 @@ def run(
         tags=tags,
         credential_manager=self._credential_manager,  # type: ignore[arg-type]
         autolog=autolog,
+        export_auth_token=api_key,
     )
 ```
 
@@ -2646,6 +2629,63 @@ def task_span(
         run_id=run.run_id if run else "",
         tracer=self._get_tracer(),
     )
+```
+
+
+</Accordion>
+
+### using\_api\_key
+
+```python
+using_api_key(api_key: str) -> t.Iterator[None]
+```
+
+Context manager to temporarily override the API key used for exporting spans.
+
+This is useful for multi-user scenarios where you want to log data
+on behalf of another user.
+
+Example
+
+```python
+with dreadnode.with_api_key("other_user_api_key"):
+    with dreadnode.run("my_run"):
+        # do some work here
+        pass
+```
+
+**Parameters:**
+
+* **`api_key`**
+  (`str`)
+  –The API key to use for exporting spans within the context.
+
+<Accordion title="Source code in dreadnode/main.py" icon="code">
+```python
+@contextlib.contextmanager
+def using_api_key(self, api_key: str) -> t.Iterator[None]:
+    """
+    Context manager to temporarily override the API key used for exporting spans.
+
+    This is useful for multi-user scenarios where you want to log data
+    on behalf of another user.
+
+    Example:
+        ~~~
+        with dreadnode.with_api_key("other_user_api_key"):
+            with dreadnode.run("my_run"):
+                # do some work here
+                pass
+        ~~~
+
+    Args:
+        api_key: The API key to use for exporting spans within the context.
+    """
+    token_token = current_export_auth_token_context.set(api_key)
+    try:
+        yield
+    finally:
+        current_export_auth_token_context.reset(token_token)
 ```
 
 

--- a/dreadnode/__init__.py
+++ b/dreadnode/__init__.py
@@ -50,6 +50,7 @@ span = DEFAULT_INSTANCE.span
 task = DEFAULT_INSTANCE.task
 task_span = DEFAULT_INSTANCE.task_span
 run = DEFAULT_INSTANCE.run
+using_api_key = DEFAULT_INSTANCE.using_api_key
 task_and_run = DEFAULT_INSTANCE.task_and_run
 scorer = DEFAULT_INSTANCE.scorer
 score = DEFAULT_INSTANCE.score

--- a/dreadnode/tracing/constants.py
+++ b/dreadnode/tracing/constants.py
@@ -33,3 +33,6 @@ EVENT_ATTRIBUTE_LINK_HASH = f"{SPAN_NAMESPACE}.link.hash"
 EVENT_ATTRIBUTE_ORIGIN_SPAN_ID = f"{SPAN_NAMESPACE}.origin.span_id"
 
 METRIC_ATTRIBUTE_SOURCE_HASH = f"{SPAN_NAMESPACE}.origin.hash"
+
+# Internal use only - used to support multi-user export flows
+SPAN_RESOURCE_ATTRIBUTE_TOKEN = "_dreadnode_token"  # noqa: S105 # nosec

--- a/dreadnode/tracing/processors.py
+++ b/dreadnode/tracing/processors.py
@@ -1,0 +1,81 @@
+import threading
+import typing as t
+from urllib.parse import urljoin
+
+from logfire._internal.exporters.dynamic_batch import DynamicBatchSpanProcessor
+from logfire._internal.exporters.remove_pending import RemovePendingSpansExporter
+from opentelemetry.exporter.otlp.proto.http import Compression
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
+
+from dreadnode.tracing.constants import SPAN_RESOURCE_ATTRIBUTE_TOKEN
+from dreadnode.version import VERSION
+
+if t.TYPE_CHECKING:
+    from opentelemetry.context import Context
+    from opentelemetry.trace import Span
+
+
+class RoutingSpanProcessor(SpanProcessor):
+    """
+    A SpanProcessor that routes spans to different BatchSpanProcessors based on
+    a token attached to the span object.
+
+    This allows a single application to export spans for multiple users/tokens
+    to the same backend.
+    """
+
+    def __init__(
+        self,
+        server_url: str,
+        default_token: str,
+        *,
+        token_header_name: str = "X-Api-Key",  # noqa: S107
+        span_token_attribute_name: str = SPAN_RESOURCE_ATTRIBUTE_TOKEN,
+    ):
+        self._server_url = server_url
+        self._default_token = default_token
+        self._token_header_name = token_header_name
+        self._span_token_attribute_name = span_token_attribute_name
+        self._processors: dict[str, SpanProcessor] = {}
+        self._lock = threading.Lock()
+        self._get_or_create_processor(self._default_token)
+
+    def _get_or_create_processor(self, token: str) -> SpanProcessor:
+        """Lazily creates and caches a BatchSpanProcessor for a given token."""
+        with self._lock:
+            if token not in self._processors:
+                headers = {"User-Agent": f"dreadnode/{VERSION}", self._token_header_name: token}
+                self._processors[token] = DynamicBatchSpanProcessor(
+                    RemovePendingSpansExporter(
+                        OTLPSpanExporter(
+                            endpoint=urljoin(self._server_url, "/api/otel/traces"),
+                            headers=headers,
+                            compression=Compression.Gzip,
+                        )
+                    )
+                )
+            return self._processors[token]
+
+    def on_start(self, span: "Span", parent_context: "Context | None" = None) -> None:
+        """No-op. Spans are routed on end."""
+
+    def on_end(self, span: ReadableSpan) -> None:
+        """Routes the span to the correct processor based on its token."""
+        # We use the resource here to prevent it from being lost during conversions
+        token = getattr(span.resource, self._span_token_attribute_name, self._default_token)
+        processor = self._get_or_create_processor(token)
+        processor.on_end(span)
+
+    def shutdown(self) -> None:
+        """Shuts down all managed processors."""
+        with self._lock:
+            for processor in self._processors.values():
+                processor.shutdown()
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        """Flushes all managed processors."""
+        with self._lock:
+            # OTel spec says this should return True only if all flushes succeed.
+            results = [p.force_flush(timeout_millis) for p in self._processors.values()]
+            return all(results)


### PR DESCRIPTION
Support tracking and exporting spans with api key overrides to support multi-user services

**Key Changes**
- Reworks our span exporter to check for an override attribute and create a dedicated export instance for those spans - routing them per api key/user.
- Added an `dn.run(..., api_key=)` argument and `with dn.using_api_key()` to override this context on demand.
- Ensured that `get_run_context` carries this override information so if we have a backend stack passing around user-local context, it's reflected in the exports.

**Example**

```python
import dreadnode as dn
import threading

OTHER_API_KEY = "..."


with dn.run("testing", project="context"):
    dn.log_input("x", 5)
    dn.log_output("z", 15)


def continue_run_in_thread(context):
    with dn.continue_run(context):
        dn.log_input("a", 10)
        dn.log_output("b", 20)

with dn.using_api_key(OTHER_API_KEY):
    with dn.run("other", project="context") as run:
        dn.log_input("y", 10)
        dn.log_output("y", 10)

        context = dn.get_run_context()
        
        thread = threading.Thread(target=continue_run_in_thread, args=(context,))
        thread.start()
        thread.join()

```

---

## Generated Summary:

### PR Description

This pull request introduces significant modifications to the SDK's tracing mechanism, enhancing support for multi-user scenarios by allowing the use of API keys for span exports.

- Refactored the `get_run_context` method to simplify the extraction of run context data.
- Introduced a new context manager, `using_api_key`, to facilitate temporary overriding of the API key used for exporting spans during nested operations.
- Added `api_key` as an optional parameter to `run` and `initialize` methods, enabling context-specific tracing.
- Replaced the `BatchSpanProcessor` with a new `RoutingSpanProcessor` that allows spans to be routed based on user-specific tokens.
- Updated the `RunContext` structure to include `export_auth_token` to maintain API key information across different contexts.
- Cleaned up unused imports and comments related to OpenTelemetry integrations.

These changes enable more flexible tracing capabilities and improve the SDK's usability in multi-user applications, allowing for controlled export configurations based on individual API keys.

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
